### PR TITLE
Add a --no-verify flag to the delete command to skip pre-push hooks and a new git squash shortcut.

### DIFF
--- a/git-functions.sh
+++ b/git-functions.sh
@@ -217,7 +217,7 @@ function git-del-branch () {
 		if [ $okToProceed -eq 1 ]; then
 			echo;
 	        echo " [DELETING] '$1' from remote origin"
-			git push origin --delete $1
+			git push origin --delete --no-verify $1
 			
 			echo;
 			echo " [DELETING] '$1' from your local repo"


### PR DESCRIPTION
- Adding the --no-verify flag speeds up deleting the remote branch by skipping any pre-push hooks.
- Adding a shortcut for squashing commits "grbi"
