### PR TITLE
Allow for creating patch from recent commits

### DIFF
--- a/git-functions.sh
+++ b/git-functions.sh
@@ -329,15 +329,31 @@ alias gun='git-assume-unchanged'
 
 ##
 # A shorthand function to create patches of changes in your current branch
+# Allows for creation of a patch of recent commits
+# Optional args[2] allows user to specify number of commits to include in patch (default is 1)
 function git-patch () {
   if [[ "$1" != "" ]]; then
-    git diff > "$1.patch"
+    difference=$(git diff)
+    if [[ "$difference" != "" ]]; then
+      git diff > "$1.patch"
+    else
+      if [[ "$2" == "" ]]; then
+        count="1"
+        commits="commit"
+      else
+        count="$2"
+        commits="$2 commits"
+      fi
+      echo "creating a patch file $1.patch for changes in last $commits"
+      git diff "HEAD~$count" > "$1.patch"
+    fi
   else
     echo;
-    echo "usage: git-patch <patch-name>  OR  gp <patch-name>"
+    echo "usage: git-patch <patch-name>  OR  gp <patch-name> [number of commits to include]"
     echo;
     echo "example: gp my-name"
     echo "example: gp \"../Some folder/my-name\""
+    echo "example: gp my-name 3"
   fi
 }
 alias gp='git-patch'

--- a/git-functions.sh
+++ b/git-functions.sh
@@ -576,3 +576,24 @@ function git-undo-commit () {
   git reset --soft HEAD~1
 }
 alias guc='git-undo-commit'
+
+##
+# Resets back to where you were before the last commit, keeps what was added.
+function git-restore-file () {
+  if [[ "$1" != "" ]]; then
+    echo;
+    echo -e " ${BCya}[RESTORING]${RCol} ${BYel}$1${RCol}"
+    echo;
+    
+    git checkout $(git rev-list -n 1 HEAD -- "$1")~1 -- "$1"
+    
+  else
+    echo;
+    echo "usage: git-restore-file <full-path-to-file>"
+    echo "       grf <full-path-to-file>"
+    echo;
+    echo "example: grf \"some/path to/a/file.js\""
+    echo;
+  fi
+}
+alias grf='git-restore-file'


### PR DESCRIPTION
#### Enhance functionality of git-patch (gp) function.

Allow user to create a patch from recent commits.
Allow user to specify number of recent commits to include in the single patch file (defaults to 1).
Maintains current functionality in place.
